### PR TITLE
Improve subscription error handling

### DIFF
--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -535,18 +535,40 @@ async def start(client, message):
             await message.reply_text(reason)
             return
 
-    if info.AUTH_CHANNEL and not await is_subscribed(client, message):
-        try:
-            invite_link = await client.create_chat_invite_link(int(info.AUTH_CHANNEL))
-        except ChatAdminRequired:
-            logger.error("Make sure Bot is admin in Force Sub channel")
-        btn = [
-            [
-                InlineKeyboardButton(
-                    "🤖 𝖩𝗈𝗂𝗇 𝖴𝗉𝖽𝖺𝗍𝖾𝗌 𝖢𝗁𝖺𝗇𝗇𝖾𝗅 🤖", url=invite_link.invite_link
+    if info.AUTH_CHANNEL:
+        subscribed = await is_subscribed(client, message)
+        if subscribed is None:
+            if info.ADMINS:
+                await client.send_message(
+                    info.ADMINS[0],
+                    "Please add me as an admin in AUTH_CHANNEL to enable force subscribe feature."
                 )
+            await message.reply_text(
+                "Subscription verification failed. Please contact the bot owner."
+            )
+            return
+        if not subscribed:
+            try:
+                invite_link = await client.create_chat_invite_link(int(info.AUTH_CHANNEL))
+            except ChatAdminRequired:
+                logger.error("Make sure Bot is admin in Force Sub channel")
+                if info.ADMINS:
+                    await client.send_message(
+                        info.ADMINS[0],
+                        "I couldn't create an invite link for AUTH_CHANNEL. Grant me admin rights."
+                    )
+                await message.reply_text(
+                    "Bot is not admin in the updates channel. Contact the bot owner."
+                )
+                return
+            btn = [
+                [
+                    InlineKeyboardButton(
+                        "🤖 𝖩𝗈𝗂𝗇 𝖴𝗉𝖽𝖺𝗍𝖾𝗌 𝖢𝗁𝖺𝗇𝗇𝖾𝗅 🤖",
+                        url=invite_link.invite_link,
+                    )
+                ]
             ]
-        ]
 
         if message.command[1] != "subscribe" or message.command[1] != "send_all":
             try:

--- a/plugins/inline.py
+++ b/plugins/inline.py
@@ -35,12 +35,24 @@ async def answer(bot, query):
                            switch_pm_parameter="hehe")
         return
 
-    if info.AUTH_CHANNEL and not await is_subscribed(bot, query):
-        await query.answer(results=[],
-                           cache_time=0,
-                           switch_pm_text='𝖸𝗈𝗎 𝖧𝖺𝗏𝖾 𝖳𝗈 𝖲𝗎𝖻𝗌𝖼𝗋𝗂𝖻𝖾 𝖬𝗒 𝖢𝗁𝖺𝗇𝗇𝖾𝗅 𝖳𝗈 𝖴𝗌𝖾 𝖬𝖾 :)',
-                           switch_pm_parameter="subscribe")
-        return
+    if info.AUTH_CHANNEL:
+        subscribed = await is_subscribed(bot, query)
+        if subscribed is None:
+            await query.answer(
+                results=[],
+                cache_time=0,
+                switch_pm_text="Subscription check failed. Contact the bot owner.",
+                switch_pm_parameter="subscribe",
+            )
+            return
+        if not subscribed:
+            await query.answer(
+                results=[],
+                cache_time=0,
+                switch_pm_text='𝖸𝗈𝗎 𝖧𝖺𝗏𝖾 𝖳𝗈 𝖲𝗎𝖻𝗌𝖼𝗋𝗂𝖻𝖾 𝖬𝗒 𝖢𝗁𝖺𝗇𝗇𝖾𝗅 𝖳𝗈 𝖴𝗌𝖾 𝖬𝗲 :)',
+                switch_pm_parameter="subscribe",
+            )
+            return
 
     user_id = query.from_user.id
     if not await db.is_user_exist(user_id):

--- a/plugins/pm_filter.py
+++ b/plugins/pm_filter.py
@@ -561,9 +561,17 @@ async def cb_handler(client: Client, query: CallbackQuery):
             return await query.answer(f"𝖧𝖾𝗒 {query.from_user.first_name}, 𝖳𝗁𝗂𝗌 𝗂𝗌 𝗇𝗈𝗍 𝗒𝗈𝗎𝗋 𝗋𝖾𝗊𝗎𝖾𝗌𝗍 !", show_alert=True)
 
         try:
-            if info.AUTH_CHANNEL and not await is_subscribed(client, query):
-                await query.answer(url=f"https://t.me/{temp.U_NAME}?start={ident}_{file_id}")
-                return
+            if info.AUTH_CHANNEL:
+                subscribed = await is_subscribed(client, query)
+                if subscribed is None:
+                    await query.answer(
+                        "Subscription check failed. Contact the bot owner.",
+                        show_alert=True,
+                    )
+                    return
+                if not subscribed:
+                    await query.answer(url=f"https://t.me/{temp.U_NAME}?start={ident}_{file_id}")
+                    return
             elif settings['botpm']:
                 await query.answer(url=f"https://t.me/{temp.U_NAME}?start={ident}_{file_id}")
                 return
@@ -594,10 +602,21 @@ async def cb_handler(client: Client, query: CallbackQuery):
             await query.answer(url=f"https://t.me/{temp.U_NAME}?start={ident}_{file_id}") # Fallback to PM
 
     elif query.data.startswith("checksub"):
-        user_id = query.from_user.id # Moved user_id retrieval up
-        if info.AUTH_CHANNEL and not await is_subscribed(client, query): # This check should be before access check
-            await query.answer("𝖨 𝖫𝗂𝗄𝖾 𝖸𝗈𝗎𝗋 𝖲𝗆𝖺𝗋𝗍𝗇𝖾𝗌𝗌, 𝖡𝗎𝗍 𝖣𝗈𝗇'𝗍 𝖡𝖾 𝖮𝗏𝖾𝗋𝗌𝗆𝖺𝗋𝗍 😒 \n𝖩𝗈𝗂𝗇 𝖴𝗉𝖽𝖺𝗍𝖾 𝖢𝗁𝖺𝗇𝗇𝖾𝗅 𝖿𝗂𝗋𝗌𝗍 ;)", show_alert=True)
-            return
+        user_id = query.from_user.id  # Moved user_id retrieval up
+        if info.AUTH_CHANNEL:
+            subscribed = await is_subscribed(client, query)
+            if subscribed is None:
+                await query.answer(
+                    "Subscription check failed. Contact the bot owner.",
+                    show_alert=True,
+                )
+                return
+            if not subscribed:
+                await query.answer(
+                    "𝖨 𝖫𝗂𝗄𝖾 𝖸𝗈𝗎𝗋 𝖲𝗆𝖺𝗋𝗍𝗇𝖾𝗌𝗌, 𝖡𝗎𝗍 𝖣𝗈𝗇'𝗍 𝖡𝖾 𝖮𝗏𝖾𝗋𝗌𝗆𝖺𝗋𝗍 😒 \n𝖩𝗈𝗂𝗇 𝖴𝗉𝖽𝖺𝗍𝖾 𝖢𝗁𝖺𝗇𝗇𝖾𝗅 𝖿𝗂𝗋𝗌𝗍 ;)",
+                    show_alert=True,
+                )
+                return
 
         # Now, check user access as they are past the subscription gate (if any)
         can_access, reason = await check_user_access(client, query.message, user_id,increment=False)


### PR DESCRIPTION
## Summary
- handle missing admin rights during subscription check
- update inline and PM handlers to show clearer messages when subscription check fails
- send notifications to admins if AUTH_CHANNEL is misconfigured

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684272aabeac832dafb3f78b5876891c