### PR TITLE
Fix custom caption placeholders

### DIFF
--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -15,7 +15,14 @@ from database.users_chats_db import db
 #from info import CHANNELS, ADMINS, AUTH_CHANNEL, LOG_CHANNEL, PICS, BATCH_FILE_CAPTION, CUSTOM_FILE_CAPTION, SUPPORT_CHAT, PROTECT_CONTENT, REQST_CHANNEL, SUPPORT_CHAT_ID, MAX_B_TN, FILE_STORE_CHANNEL, PUBLIC_FILE_STORE, KEEP_ORIGINAL_CAPTION, initialize_configuration
 import info
 from info import PREMIUM_DURATION_DAYS, NON_PREMIUM_DAILY_LIMIT  # Added
-from utils import get_settings, get_size, is_subscribed, save_group_settings, temp
+from utils import (
+    get_settings,
+    get_size,
+    is_subscribed,
+    save_group_settings,
+    temp,
+    render_caption,
+)
 from database.connections_mdb import active_connection
 import re
 import json
@@ -644,11 +651,13 @@ async def start(client, message):
                     f_caption = file_item.file_name
             elif info.CUSTOM_FILE_CAPTION:
                 try:
-                    f_caption = info.CUSTOM_FILE_CAPTION.format(file_name='' if title is None else title,
-                                                                file_size='' if size is None else size,
-                                                                file_caption='' if getattr(file_item, 'caption',
-                                                                                           None) is None else file_item.caption)
-                except:
+                    f_caption = render_caption(
+                        info.CUSTOM_FILE_CAPTION,
+                        title=title,
+                        size=size,
+                        caption=getattr(file_item, 'caption', None),
+                    )
+                except Exception:
                     f_caption = getattr(file_item, 'caption', file_item.file_name)  # Fallback
             if f_caption is None:
                 f_caption = f"{file_item.file_name}"
@@ -728,10 +737,12 @@ async def start(client, message):
                     f_caption = msg_item.get("title")
             elif info.BATCH_FILE_CAPTION:
                 try:
-                    f_caption = info.BATCH_FILE_CAPTION.format(file_name='' if title is None else title,
-                                                               file_size='' if size is None else size,
-                                                               file_caption='' if msg_item.get(
-                                                                   "caption") is None else msg_item.get("caption"))
+                    f_caption = render_caption(
+                        info.BATCH_FILE_CAPTION,
+                        title=title,
+                        size=size,
+                        caption=msg_item.get("caption"),
+                    )
                 except Exception as e:
                     logger.exception(e)
                     f_caption = msg_item.get("caption", title)  # Fallback
@@ -808,9 +819,12 @@ async def start(client, message):
                         f_caption = getattr(media, 'file_name', '')
                 elif info.BATCH_FILE_CAPTION:  # Using BATCH_FILE_CAPTION for DSTORE as well
                     try:
-                        f_caption = info.BATCH_FILE_CAPTION.format(file_name=getattr(media, 'file_name', ''),
-                                                                   file_size=getattr(media, 'file_size', 0),
-                                                                   file_caption=getattr(dstore_msg_item, 'caption', ''))
+                        f_caption = render_caption(
+                            info.BATCH_FILE_CAPTION,
+                            title=getattr(media, 'file_name', ''),
+                            size=getattr(media, 'file_size', 0),
+                            caption=getattr(dstore_msg_item, 'caption', ''),
+                        )
                     except Exception as e:
                         logger.exception(e)
                         f_caption = getattr(dstore_msg_item, 'caption', '')
@@ -886,9 +900,12 @@ async def start(client, message):
         pass
     elif info.CUSTOM_FILE_CAPTION:
         try:
-            f_caption = info.CUSTOM_FILE_CAPTION.format(file_name='' if title is None else title,
-                                                        file_size='' if size is None else size,
-                                                        file_caption='' if f_caption is None else f_caption)
+            f_caption = render_caption(
+                info.CUSTOM_FILE_CAPTION,
+                title=title,
+                size=size,
+                caption=f_caption,
+            )
         except Exception as e:
             logger.exception(e)
             # Keep original f_caption if template fails

--- a/plugins/inline.py
+++ b/plugins/inline.py
@@ -8,7 +8,7 @@ from database.connections_mdb import active_connection
 from database.ia_filterdb import get_search_results
 from database.users_chats_db import db # Added db import
 import info
-from utils import is_subscribed, get_size, temp
+from utils import is_subscribed, get_size, temp, render_caption
 
 logger = logging.getLogger(__name__)
 cache_time = 0 if info.AUTH_USERS or info.AUTH_CHANNEL else info.CACHE_TIME
@@ -183,7 +183,12 @@ async def answer(bot, query):
                 f_caption = f"<code>{title}</code>"
         elif info.CUSTOM_FILE_CAPTION:
             try:
-                f_caption=info.CUSTOM_FILE_CAPTION.format(file_name= '' if title is None else title, file_size='' if size is None else size, file_caption='' if f_caption is None else f_caption)
+                f_caption = render_caption(
+                    info.CUSTOM_FILE_CAPTION,
+                    title=title,
+                    size=size,
+                    caption=f_caption,
+                )
             except Exception as e:
                 logger.exception(e)
                 f_caption=f_caption

--- a/plugins/pm_filter.py
+++ b/plugins/pm_filter.py
@@ -14,7 +14,15 @@ import info
 from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton, CallbackQuery, InputMediaPhoto
 from pyrogram import Client, filters, enums
 from pyrogram.errors import UserIsBlocked, MessageNotModified, PeerIdInvalid
-from utils import get_size, is_subscribed, get_poster, temp, get_settings, save_group_settings
+from utils import (
+    get_size,
+    is_subscribed,
+    get_poster,
+    temp,
+    get_settings,
+    save_group_settings,
+    render_caption,
+)
 from database.users_chats_db import db
 from database.ia_filterdb import Media, get_file_details, get_search_results, get_bad_files
 from database.filters_mdb import (
@@ -547,9 +555,12 @@ async def cb_handler(client: Client, query: CallbackQuery):
                 f_caption = f"{title}"
         elif info.CUSTOM_FILE_CAPTION:
             try:
-                f_caption = info.CUSTOM_FILE_CAPTION.format(file_name='' if title is None else title,
-                                                       file_size='' if size is None else size,
-                                                       file_caption='' if f_caption is None else f_caption)
+                f_caption = render_caption(
+                    info.CUSTOM_FILE_CAPTION,
+                    title=title,
+                    size=size,
+                    caption=f_caption,
+                )
             except Exception as e:
                 logger.exception(e)
             # f_caption = f_caption # This line was redundant, f_caption is already itself
@@ -639,9 +650,12 @@ async def cb_handler(client: Client, query: CallbackQuery):
                 f_caption = f"{title}"
         elif info.CUSTOM_FILE_CAPTION: # Ensure this is 'elif' not 'if' to avoid double processing
             try:
-                f_caption = info.CUSTOM_FILE_CAPTION.format(file_name='' if title is None else title,
-                                                       file_size='' if size is None else size,
-                                                       file_caption='' if f_caption is None else f_caption)
+                f_caption = render_caption(
+                    info.CUSTOM_FILE_CAPTION,
+                    title=title,
+                    size=size,
+                    caption=f_caption,
+                )
             except Exception as e:
                 logger.exception(e)
                 # f_caption remains as it was before this block if CUSTOM_FILE_CAPTION fails


### PR DESCRIPTION
## Summary
- add `render_caption` helper to support multiple placeholder names
- handle custom captions via `render_caption` in plugins
- import new helper in modules

## Testing
- `python -m compileall -q utils.py plugins/pm_filter.py plugins/inline.py plugins/commands.py`

------
https://chatgpt.com/codex/tasks/task_e_684279542374832dbb68a8a14ff82455