### PR TITLE
Add DISABLE_PREMIUM option

### DIFF
--- a/info.py
+++ b/info.py
@@ -39,6 +39,7 @@ CACHE_TIME = int(environ.get('CACHE_TIME', 300))
 USE_CAPTION_FILTER = bool(environ.get('USE_CAPTION_FILTER', True))
 PREMIUM_DURATION_DAYS = int(environ.get('PREMIUM_DURATION_DAYS', 30))
 NON_PREMIUM_DAILY_LIMIT = int(environ.get('NON_PREMIUM_DAILY_LIMIT', 10))
+DISABLE_PREMIUM = is_enabled(environ.get('DISABLE_PREMIUM', 'False'), False)
 MESSAGE_DELETE_SECONDS = int(environ.get('MESSAGE_DELETE_SECONDS', 300))
 
 # Bot images & videos
@@ -96,7 +97,14 @@ POWERED_BY = environ.get("POWERED_BY", "@kdramaworld_ongoing")
 SUPPORT_GROUP = environ.get("SUPPORT_GROUP", "https://t.me/kdramasmirrorchat")
 SUPPORT_GROUP_USERNAME = environ.get("SUPPORT_GROUP_USERNAME", "@kdramasmirrorchat")
 MAIN_CHANNEL = environ.get("MAIN_CHANNEL", "https://t.me/kdramaworld_ongoing")
-START_TEXT = environ.get("START_TEXT", f"HELLO!! This bot offers a premium plan valid for 30 days with unlimited file retrievals. Free users can retrieve up to {NON_PREMIUM_DAILY_LIMIT} files per day. Check out /plans for more details.")
+if DISABLE_PREMIUM:
+    default_start = "HELLO!! You can retrieve files without any limits."
+else:
+    default_start = (
+        f"HELLO!! This bot offers a premium plan valid for 30 days with unlimited file retrievals. "
+        f"Free users can retrieve up to {NON_PREMIUM_DAILY_LIMIT} files per day. Check out /plans for more details."
+    )
+START_TEXT = environ.get("START_TEXT", default_start)
 
 # A log string (for informational purposes)
 LOG_STR = "Current Cusomized Configurations are:-\n"
@@ -185,6 +193,7 @@ def get_config_data_from_env():
         "START_TEXT": START_TEXT,
         "PREMIUM_DURATION_DAYS": PREMIUM_DURATION_DAYS,
         "NON_PREMIUM_DAILY_LIMIT": NON_PREMIUM_DAILY_LIMIT,
+        "DISABLE_PREMIUM": DISABLE_PREMIUM,
         "MESSAGE_DELETE_SECONDS": MESSAGE_DELETE_SECONDS,
     }
     return config_data
@@ -256,5 +265,6 @@ MAIN_CHANNEL = CONFIG.get("MAIN_CHANNEL")
 START_TEXT = CONFIG.get("START_TEXT")
 PREMIUM_DURATION_DAYS = CONFIG.get("PREMIUM_DURATION_DAYS", PREMIUM_DURATION_DAYS)
 NON_PREMIUM_DAILY_LIMIT = CONFIG.get("NON_PREMIUM_DAILY_LIMIT", NON_PREMIUM_DAILY_LIMIT)
+DISABLE_PREMIUM = CONFIG.get("DISABLE_PREMIUM", DISABLE_PREMIUM)
 MESSAGE_DELETE_SECONDS = CONFIG.get("MESSAGE_DELETE_SECONDS", MESSAGE_DELETE_SECONDS)
 

--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -36,6 +36,8 @@ OWNER_ID = info.ADMINS[0] if info.ADMINS else None
 
 async def check_user_access(client, message, user_id, *, increment: bool = False):
     """Checks user access, handles premium status, and daily limits."""
+    if info.DISABLE_PREMIUM:
+        return True, "Premium disabled"
     if OWNER_ID and user_id == OWNER_ID:
         return True, "Owner access: Unlimited"
 
@@ -200,6 +202,9 @@ async def remove_premium_command(client, message):
 
 @Client.on_message(filters.command("plans") & filters.private)
 async def plans_command(client: Client, message: Message):
+    if info.DISABLE_PREMIUM:
+        await message.reply_text("Premium features are currently disabled.")
+        return
     user_id = message.from_user.id
     user_data = await db.get_user_data(user_id)  # Returns None if user not found
 

--- a/plugins/inline.py
+++ b/plugins/inline.py
@@ -130,10 +130,10 @@ async def answer(bot, query):
         
         # Check if this non-premium user has reached their daily view limit for inline queries.
         # Note: This count is for *viewing* results. Actual file retrieval count is handled in commands.py.
-        if effective_count_for_today >= info.NON_PREMIUM_DAILY_LIMIT:
-            await query.answer(results=[], 
-                               cache_time=0, 
-                               switch_pm_text=f"Daily file view limit ({info.NON_PREMIUM_DAILY_LIMIT}) reached. Upgrade for more.\nUse /plans command to view premium plans for unlimited access.", 
+        if not info.DISABLE_PREMIUM and effective_count_for_today >= info.NON_PREMIUM_DAILY_LIMIT:
+            await query.answer(results=[],
+                               cache_time=0,
+                               switch_pm_text=f"Daily file view limit ({info.NON_PREMIUM_DAILY_LIMIT}) reached. Upgrade for more.\nUse /plans command to view premium plans for unlimited access.",
                                switch_pm_parameter="premium_limit_inline")
             return # User cannot proceed with this query
         


### PR DESCRIPTION
## Summary
- add `DISABLE_PREMIUM` setting to configuration
- update start text logic when premium is disabled
- allow skipping premium checks in command and inline logic
- disable `/plans` when premium system is turned off

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856c3f9502c832d8472c8e12987888d