### PR TITLE
Improve database concurrency

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,6 +11,7 @@ from pyrogram import Client, __version__
 from pyrogram.raw.all import layer
 from database.ia_filterdb import Media
 from database.users_chats_db import db
+from database.db_client import close as close_db_client
 from info import SESSION, API_ID, API_HASH, BOT_TOKEN, LOG_STR, LOG_CHANNEL, PORT
 from utils import temp
 from typing import Union, Optional, AsyncGenerator
@@ -64,6 +65,7 @@ class Bot(Client):
 
     async def stop(self, *args):
         await super().stop()
+        await close_db_client()
         logging.info("Bot stopped. Bye.")
 
     async def iter_messages(

--- a/database/db_client.py
+++ b/database/db_client.py
@@ -1,0 +1,16 @@
+import asyncio
+from motor.motor_asyncio import AsyncIOMotorClient
+import info
+
+# Use a single Mongo client with connection pooling
+# maxPoolSize can be tuned based on expected concurrency
+client = AsyncIOMotorClient(info.DATABASE_URI, maxPoolSize=100)
+
+# Reference to the default database
+db = client[info.DATABASE_NAME]
+
+# Semaphore to limit concurrent DB operations
+mongo_sem = asyncio.Semaphore(100)
+
+async def close():
+    client.close()

--- a/database/filters_mdb.py
+++ b/database/filters_mdb.py
@@ -1,19 +1,17 @@
-import motor.motor_asyncio
 import info
 from pyrogram import enums
 import logging
+from .db_client import db, mongo_sem
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.ERROR)
 
-client = motor.motor_asyncio.AsyncIOMotorClient(info.DATABASE_URI)
-db = client[info.DATABASE_NAME]
 
 
 async def add_filter(grp_id, text, reply_text, btn, file, alert):
     collection = db[str(grp_id)]
-    # If needed, you can uncomment and await the index creation:
-    # await collection.create_index([('text', 'text')])
+    async with mongo_sem:
+        await collection.create_index('text')
     
     data = {
         'text': str(text),
@@ -24,7 +22,8 @@ async def add_filter(grp_id, text, reply_text, btn, file, alert):
     }
     
     try:
-        await collection.update_one({'text': str(text)}, {"$set": data}, upsert=True)
+        async with mongo_sem:
+            await collection.update_one({'text': str(text)}, {"$set": data}, upsert=True)
     except Exception:
         logger.exception('Some error occurred while updating the filter!', exc_info=True)
              
@@ -33,7 +32,8 @@ async def find_filter(group_id, name):
     collection = db[str(group_id)]
     try:
         # Using find_one to retrieve a single matching filter
-        doc = await collection.find_one({"text": name})
+        async with mongo_sem:
+            doc = await collection.find_one({"text": name})
         if doc is None:
             return None, None, None, None
         
@@ -65,9 +65,11 @@ async def delete_filter(message, text, group_id):
     collection = db[str(group_id)]
     myquery = {'text': text}
     try:
-        count = await collection.count_documents(myquery)
+        async with mongo_sem:
+            count = await collection.count_documents(myquery)
         if count == 1:
-            await collection.delete_one(myquery)
+            async with mongo_sem:
+                await collection.delete_one(myquery)
             await message.reply_text(
                 f"'`{text}`'  deleted. I'll not respond to that filter anymore.",
                 quote=True,
@@ -81,13 +83,15 @@ async def delete_filter(message, text, group_id):
 
 async def del_all(message, group_id, title):
     try:
-        collection_names = await db.list_collection_names()
+        async with mongo_sem:
+            collection_names = await db.list_collection_names()
         if str(group_id) not in collection_names:
             await message.edit_text(f"Nothing to remove in {title}!")
             return
 
         collection = db[str(group_id)]
-        await collection.drop()
+        async with mongo_sem:
+            await collection.drop()
         await message.edit_text(f"All filters from {title} have been removed")
     except Exception:
         logger.exception("Error occurred during del_all", exc_info=True)
@@ -97,7 +101,8 @@ async def del_all(message, group_id, title):
 async def count_filters(group_id):
     collection = db[str(group_id)]
     try:
-        count = await collection.count_documents({})
+        async with mongo_sem:
+            count = await collection.count_documents({})
         return False if count == 0 else count
     except Exception:
         logger.exception("Error occurred during count_filters", exc_info=True)
@@ -106,14 +111,16 @@ async def count_filters(group_id):
 
 async def filter_stats():
     try:
-        collection_names = await db.list_collection_names()
+        async with mongo_sem:
+            collection_names = await db.list_collection_names()
         if "CONNECTION" in collection_names:
             collection_names.remove("CONNECTION")
 
         total_count = 0
         for coll_name in collection_names:
             collection = db[coll_name]
-            cnt = await collection.count_documents({})
+            async with mongo_sem:
+                cnt = await collection.count_documents({})
             total_count += cnt
 
         total_collections = len(collection_names)

--- a/database/users_chats_db.py
+++ b/database/users_chats_db.py
@@ -1,12 +1,11 @@
-import motor.motor_asyncio
 import info
+from .db_client import db as global_db, mongo_sem
 from datetime import datetime, date,time
 
 class Database:
     
-    def __init__(self, uri, database_name):
-        self._client = motor.motor_asyncio.AsyncIOMotorClient(uri)
-        self.db = self._client[database_name]
+    def __init__(self):
+        self.db = global_db
         self.col = self.db.users   # Users collection
         self.grp = self.db.groups  # Groups collection
 
@@ -36,14 +35,17 @@ class Database:
     
     async def add_user(self, id, name):
         user = self.new_user(id, name)
-        await self.col.insert_one(user)
+        async with mongo_sem:
+            await self.col.insert_one(user)
     
     async def is_user_exist(self, id):
-        user = await self.col.find_one({'id': int(id)})
+        async with mongo_sem:
+            user = await self.col.find_one({'id': int(id)})
         return bool(user)
     
     async def total_users_count(self):
-        count = await self.col.count_documents({})
+        async with mongo_sem:
+            count = await self.col.count_documents({})
         return count
     
     async def remove_ban(self, id):
@@ -51,31 +53,36 @@ class Database:
             'is_banned': False,
             'ban_reason': ''
         }
-        await self.col.update_one({'id': id}, {'$set': {'ban_status': ban_status}})
+        async with mongo_sem:
+            await self.col.update_one({'id': id}, {'$set': {'ban_status': ban_status}})
     
     async def ban_user(self, user_id, ban_reason="No Reason"):
         ban_status = {
             'is_banned': True,
             'ban_reason': ban_reason
         }
-        await self.col.update_one({'id': user_id}, {'$set': {'ban_status': ban_status}})
+        async with mongo_sem:
+            await self.col.update_one({'id': user_id}, {'$set': {'ban_status': ban_status}})
 
     async def get_ban_status(self, id):
         default = {
             'is_banned': False,
             'ban_reason': ''
         }
-        user = await self.col.find_one({'id': int(id)})
+        async with mongo_sem:
+            user = await self.col.find_one({'id': int(id)})
         if not user:
             return default
         return user.get('ban_status', default)
 
     async def get_all_users(self):
         # Returns a list of all user documents
-        return await self.col.find({}).to_list(length=None)
+        async with mongo_sem:
+            return await self.col.find({}).to_list(length=None)
     
     async def delete_user(self, user_id):
-        await self.col.delete_many({'id': int(user_id)})
+        async with mongo_sem:
+            await self.col.delete_many({'id': int(user_id)})
 
     async def get_banned(self):
         # Returns lists of banned user IDs and disabled chat IDs
@@ -87,10 +94,12 @@ class Database:
 
     async def add_chat(self, chat, title):
         chat_doc = self.new_group(chat, title)
-        await self.grp.insert_one(chat_doc)
+        async with mongo_sem:
+            await self.grp.insert_one(chat_doc)
     
     async def get_chat(self, chat):
-        chat_doc = await self.grp.find_one({'id': int(chat)})
+        async with mongo_sem:
+            chat_doc = await self.grp.find_one({'id': int(chat)})
         return False if not chat_doc else chat_doc.get('chat_status')
     
     async def re_enable_chat(self, id):
@@ -98,10 +107,12 @@ class Database:
             'is_disabled': False,
             'reason': "",
         }
-        await self.grp.update_one({'id': int(id)}, {'$set': {'chat_status': chat_status}})
+        async with mongo_sem:
+            await self.grp.update_one({'id': int(id)}, {'$set': {'chat_status': chat_status}})
         
     async def update_settings(self, id, settings):
-        await self.grp.update_one({'id': int(id)}, {'$set': {'settings': settings}})
+        async with mongo_sem:
+            await self.grp.update_one({'id': int(id)}, {'$set': {'settings': settings}})
         
     async def get_settings(self, id):
         default = {
@@ -116,7 +127,8 @@ class Database:
             'max_btn': info.MAX_BTN,
             'template': info.IMDB_TEMPLATE
         }
-        chat_doc = await self.grp.find_one({'id': int(id)})
+        async with mongo_sem:
+            chat_doc = await self.grp.find_one({'id': int(id)})
         if chat_doc:
             return chat_doc.get('settings', default)
         return default
@@ -126,30 +138,36 @@ class Database:
             'is_disabled': True,
             'reason': reason,
         }
-        await self.grp.update_one({'id': int(chat)}, {'$set': {'chat_status': chat_status}})
+        async with mongo_sem:
+            await self.grp.update_one({'id': int(chat)}, {'$set': {'chat_status': chat_status}})
     
     async def total_chat_count(self):
-        count = await self.grp.count_documents({})
+        async with mongo_sem:
+            count = await self.grp.count_documents({})
         return count
     
     async def get_all_chats(self):
         # Returns a list of all group documents
-        return await self.grp.find({}).to_list(length=None)
+        async with mongo_sem:
+            return await self.grp.find({}).to_list(length=None)
     
     async def get_db_size(self):
         # Returns the database size (dataSize in bytes)
-        stats = await self.db.command("dbstats")
+        async with mongo_sem:
+            stats = await self.db.command("dbstats")
         return stats.get('dataSize', 0)
 
     async def update_premium_status(self, user_id, is_premium):
         activation_date = datetime.now() if is_premium else None
-        await self.col.update_one(
-            {'id': user_id},
-            {'$set': {'is_premium': is_premium, 'premium_activation_date': activation_date}}
-        )
+        async with mongo_sem:
+            await self.col.update_one(
+                {'id': user_id},
+                {'$set': {'is_premium': is_premium, 'premium_activation_date': activation_date}}
+            )
 
     async def increment_retrieval_count(self, user_id):
-        user = await self.col.find_one({'id': user_id})
+        async with mongo_sem:
+            user = await self.col.find_one({'id': user_id})
         if not user:
             # This case should ideally not be hit if add_user is called correctly before this.
             # Returning a very high number will cause the limit check to fail.
@@ -173,18 +191,20 @@ class Database:
         daily_retrieval_count += 1
         
         # Store today's date (as a date object, Motor/MongoDB will handle BSON conversion)
-        await self.col.update_one(
-            {'id': user_id},
-            {'$set': {
-                'daily_retrieval_count': daily_retrieval_count, 
-                'last_retrieval_date': today_dt  # Storing datetime.date object
+        async with mongo_sem:
+            await self.col.update_one(
+                {'id': user_id},
+                {'$set': {
+                    'daily_retrieval_count': daily_retrieval_count,
+                    'last_retrieval_date': today_dt
+                    }
                 }
-            }
-        )
+            )
         return daily_retrieval_count
 
     async def get_user_data(self, user_id):
-        user = await self.col.find_one({'id': user_id})
+        async with mongo_sem:
+            user = await self.col.find_one({'id': user_id})
         if not user:
             return None
         
@@ -196,4 +216,4 @@ class Database:
         }
 
 
-db = Database(info.DATABASE_URI, info.DATABASE_NAME)
+db = Database()


### PR DESCRIPTION
## Summary
- centralize MongoDB connection with pooling
- guard DB operations with a semaphore for concurrency control
- add text indexes when adding filters
- use shared DB client across modules
- close DB client on shutdown

## Testing
- `python -m py_compile bot.py database/*.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688a50180ae0832d8aba5c0bee50d91e